### PR TITLE
Fix summarization agent output parsing

### DIFF
--- a/src/agents/Summarize.ts
+++ b/src/agents/Summarize.ts
@@ -49,10 +49,14 @@ export class SummarizationAgent {
 
       // Call the Python agent using execa
       const [execError, output] = await to(
-        execa(this.pythonCommand, [...this.pythonArgs, 'agent.py', '--summarize'], {
-          cwd: this.agentPath,
-          input: nodesJson,
-        }),
+        execa(
+          this.pythonCommand,
+          [...this.pythonArgs, 'agent.py', '--quiet', '--summarize'],
+          {
+            cwd: this.agentPath,
+            input: nodesJson,
+          },
+        ),
       );
 
       // Handle execution errors


### PR DESCRIPTION
## Summary
- call `agent.py` with `--quiet` to suppress extraneous output from the summarizer

## Testing
- `npm test`