### PR TITLE
Fix artifact loss during DAG node parsing

### DIFF
--- a/src/engine/KnowledgeGraph.ts
+++ b/src/engine/KnowledgeGraph.ts
@@ -72,6 +72,7 @@ export class KnowledgeGraphManager {
     target: z.string().optional(),
     summarizedSegment: z.array(z.string()).optional(),
     tags: z.array(z.string()).optional(),
+    artifacts: z.array(FILE_REF).optional(),
   });
 
   constructor(logger: CodeLoopsLogger) {


### PR DESCRIPTION
## Summary
- include the `artifacts` field in `DagNodeSchema`

## Testing
- `npm test`