### PR TITLE
Add placeholder generative ai dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "codeloops",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codeloops",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "ISC",
       "dependencies": {
+        "@google/generative-ai": "^x.y.z",
         "@modelcontextprotocol/sdk": "^1.11.0",
         "@tsconfig/node22": "^22.0.1",
         "await-to-js": "^3.0.0",
@@ -886,6 +887,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "x.y.z",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-x.y.z.tgz",
+      "integrity": "sha512-PLACEHOLDER",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "vitest": "^3.1.2"
   },
   "dependencies": {
+    "@google/generative-ai": "^x.y.z",
     "@modelcontextprotocol/sdk": "^1.11.0",
     "@tsconfig/node22": "^22.0.1",
     "await-to-js": "^3.0.0",


### PR DESCRIPTION
## Summary
- add `@google/generative-ai` placeholder version to `package.json`
- reflect the change in `package-lock.json`
- run unit tests

## Testing
- `npm install` *(fails: Invalid tag name "^x.y.z" of package)*
- `npm test`