### PR TITLE
Add Gemini model example in config templates

### DIFF
--- a/agents/critic/fastagent.config.template.yaml
+++ b/agents/critic/fastagent.config.template.yaml
@@ -6,6 +6,7 @@
 #
 # Takes format:
 #   <provider>.<model_string>.<reasoning_effort?> (e.g. anthropic.claude-3-5-sonnet-20241022 or openai.o3-mini.low)
+# Example Gemini model: google.gemini-pro
 # Accepts aliases for Anthropic Models: haiku, haiku3, sonnet, sonnet35, opus, opus3
 # and OpenAI Models: gpt-4.1, gpt-4.1-mini, o1, o1-mini, o3-mini
 #

--- a/agents/summarize/fastagent.config.template.yaml
+++ b/agents/summarize/fastagent.config.template.yaml
@@ -6,6 +6,7 @@
 #
 # Takes format:
 #   <provider>.<model_string>.<reasoning_effort?> (e.g. anthropic.claude-3-5-sonnet-20241022 or openai.o3-mini.low)
+# Example Gemini model: google.gemini-pro
 # Accepts aliases for Anthropic Models: haiku, haiku3, sonnet, sonnet35, opus, opus3
 # and OpenAI Models: gpt-4.1, gpt-4.1-mini, o1, o1-mini, o3-mini
 #


### PR DESCRIPTION
## Summary
- add a Gemini model example to `fastagent.config.template.yaml` for both agents

## Testing
- `npm test`