### PR TITLE
Add Gemini config instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,26 @@ The script automates:
 - Verifying prerequisites (Node.js, Python, uv).
 - Installing dependencies.
 - Configuring Python environments.
-- Prompting for API key setup for models like Anthropic or OpenAI.
+- Prompting for API key setup for models like Anthropic, OpenAI, or Google Gemini.
 
 > **Tip**: I’ve had great results with Anthropic’s Haiku 3.5, costing about $0.60 weekly. It’s a solid starting point.
 
 If this script fails, see [install guide](./docs/INSTALL_GUIDE.md) for installing the project dependencies
+
+### Gemini Support
+
+CodeLoops also supports Google's Gemini models. Add a `google:` section with your API key in each `agents/*/fastagent.secrets.yaml` file:
+
+```yaml
+google:
+  api_key: your-gemini-api-key
+```
+
+Set a Gemini model as the default by editing `fastagent.config.yaml`:
+
+```yaml
+default_model: google.gemini-pro
+```
 
 ### Configure Your Agent
 

--- a/docs/INSTALL_GUIDE.md
+++ b/docs/INSTALL_GUIDE.md
@@ -89,14 +89,17 @@ The Critic and Summarization agents require separate Python environments managed
    cp fastagent.secrets.template.yaml fastagent.secrets.yaml
    ```
 4. Edit `fastagent.secrets.yaml` to include your LLM API key:
-   ```yaml
-   anthropic:
-     api_key: your-anthropic-api-key
-   # Example for OpenAI
-   openai:
-     api_key: your-openai-api-key
-   ```
-   Replace `your-anthropic-api-key` or `your-openai-api-key` with your actual keys.
+  ```yaml
+  anthropic:
+    api_key: your-anthropic-api-key
+  # Example for OpenAI
+  openai:
+    api_key: your-openai-api-key
+  # Example for Gemini
+  google:
+    api_key: your-gemini-api-key
+  ```
+  Replace `your-anthropic-api-key` or `your-openai-api-key` with your actual keys.
 5. Verify configuration:
    ```bash
    uv run fast-agent check
@@ -138,6 +141,28 @@ The `uv sync` command:
 - Generates a `uv.lock` file for reproducible builds
 
 If `uv sync` fails, ensure `uv` is installed and Python 3.11+ is available.
+
+### Gemini Support
+
+CodeLoops works with Google's Gemini models through fast-agent.
+
+1. In each agent directory, add a `google:` section with your API key in
+   `fastagent.secrets.yaml`:
+
+   ```yaml
+   google:
+     api_key: your-gemini-api-key
+   ```
+
+2. To use a Gemini model by default, set `default_model` in
+   `fastagent.config.yaml`:
+
+   ```yaml
+   default_model: google.gemini-pro
+   ```
+
+The template files already include commented Gemini lines that you can
+uncomment when needed.
 
 ### Step 5: Test the MCP Server
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -196,6 +196,9 @@ if [ "$CRITIC_SECRETS_CREATED" = true ] || [ "$SUMMARIZE_SECRETS_CREATED" = true
   echo -e "  # OR"
   echo -e "  openai:"
   echo -e "    api_key: your-api-key-here"
+  echo -e "  # OR"
+  echo -e "  google:"
+  echo -e "    api_key: your-gemini-api-key"
   echo -e "\n${YELLOW}Please edit these files before starting the server.${NC}"
 else
   echo -e "${GREEN}API key configuration files already exist.${NC}"


### PR DESCRIPTION
## Summary
- add Gemini info and example `google:` snippet to setup docs
- show how to set a Gemini model in docs
- print Google API key example in `setup.sh`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
