### PR TITLE
Implement Gemini cache helper

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -8,3 +8,13 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 export const dataDir = path.resolve(__dirname, '..', 'data');
+
+// -----------------------------------------------------------------------------
+// Gemini Configuration --------------------------------------------------------
+// -----------------------------------------------------------------------------
+
+/**
+ * Default cache TTL (in seconds) for Gemini context caching.
+ * Configurable via the GEMINI_CACHE_TTL environment variable.
+ */
+export const GEMINI_CACHE_TTL = Number.parseInt(process.env.GEMINI_CACHE_TTL ?? '3600', 10);

--- a/src/utils/geminiCache.ts
+++ b/src/utils/geminiCache.ts
@@ -1,0 +1,31 @@
+import { GoogleGenAI, type Content } from '@google/genai';
+import { GEMINI_CACHE_TTL } from '../config.ts';
+
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+if (!GEMINI_API_KEY) {
+  throw new Error('GEMINI_API_KEY environment variable not set');
+}
+
+const ai = new GoogleGenAI({ apiKey: GEMINI_API_KEY });
+
+const promptCache = new Map<string, string>();
+
+export async function getCacheId(prompt: string, ttl: number = GEMINI_CACHE_TTL): Promise<string> {
+  if (promptCache.has(prompt)) {
+    return promptCache.get(prompt)!;
+  }
+
+  const contents: Content[] = [{ role: 'user', parts: [{ text: prompt }] }];
+  const response = await ai.caches.create({
+    model: 'gemini-1.5-flash',
+    config: {
+      contents,
+      ttl: `${ttl}s`,
+      displayName: `prompt-${Math.random().toString(36).slice(2)}`,
+    },
+  });
+
+  const cacheId = response.name as string;
+  promptCache.set(prompt, cacheId);
+  return cacheId;
+}


### PR DESCRIPTION
## Summary
- add config option `GEMINI_CACHE_TTL`
- implement `getCacheId()` helper for Gemini caching

## Testing
- `npm run format -- --ignore-unknown`
- `npm run lint`
- `npm test`
