### PR TITLE
Add Gemini input cache docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ Set a Gemini model as the default by editing `fastagent.config.yaml`:
 default_model: google.gemini-pro
 ```
 
+### Gemini Input Caching
+
+CodeLoops can store Gemini prompt context using the caching API. Set the
+`GEMINI_CACHE_TTL` environment variable (seconds) to control how long cached
+inputs remain. See
+[`genai-node-reference.md`](./genai-node-reference.md) for details on the
+Gemini caching API.
+
 ### Configure Your Agent
 
 Connect your agent to the CodeLoops server by adding the MCP server configuration. Most platforms follow a similar structure:

--- a/docs/INSTALL_GUIDE.md
+++ b/docs/INSTALL_GUIDE.md
@@ -164,6 +164,14 @@ CodeLoops works with Google's Gemini models through fast-agent.
 The template files already include commented Gemini lines that you can
 uncomment when needed.
 
+#### Gemini Input Caching
+
+You can store Gemini prompt context using the caching API. Set the
+`GEMINI_CACHE_TTL` environment variable (in seconds) before starting the server
+to control how long cached inputs persist. See
+[genai-node-reference.md](../genai-node-reference.md) for details on the Gemini
+caching API.
+
 ### Step 5: Test the MCP Server
 
 1. Start the MCP server:


### PR DESCRIPTION
## Summary
- document how to enable Gemini input caching
- note `GEMINI_CACHE_TTL` env var in README and INSTALL_GUIDE

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
