### PR TITLE
Add search feature to knowledge graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ CodeLoops provides tools to enable autonomous agent operation:
 - `actor_think`: Drives interaction with the actor-critic system, automatically triggering critic reviews when needed.
 - `resume`: Retrieves recent branch context for continuity.
 - `export`: Exports the current graph for agent review.
+- `search_nodes`: Filter nodes by tags or a text query.
 - `summarize`: Generates a summary of branch progress.
 - `list_projects`: Displays all projects for navigation.
 

--- a/src/engine/KnowledgeGraph.test.ts
+++ b/src/engine/KnowledgeGraph.test.ts
@@ -220,6 +220,49 @@ describe('KnowledgeGraphManager', () => {
     });
   });
 
+  describe('search', () => {
+    it('should find nodes by tag', async () => {
+      const nodeA = createTestNode('test-project');
+      nodeA.tags = ['alpha'];
+      await kg.appendEntity(nodeA);
+
+      const nodeB = createTestNode('test-project');
+      nodeB.tags = ['beta'];
+      await kg.appendEntity(nodeB);
+
+      const results = await kg.search({ project: 'test-project', tags: ['alpha'] });
+      expect(results.map((n) => n.id)).toEqual([nodeA.id]);
+    });
+
+    it('should find nodes by substring', async () => {
+      const node = createTestNode('test-project');
+      node.thought = 'Implement search feature';
+      await kg.appendEntity(node);
+
+      const results = await kg.search({ project: 'test-project', query: 'search' });
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe(node.id);
+    });
+
+    it('should combine tag and query filters', async () => {
+      const node = createTestNode('test-project');
+      node.tags = ['gamma'];
+      node.thought = 'Gamma thought here';
+      await kg.appendEntity(node);
+
+      const wrongTag = await kg.search({
+        project: 'test-project',
+        tags: ['other'],
+        query: 'Gamma',
+      });
+      expect(wrongTag).toEqual([]);
+
+      const good = await kg.search({ project: 'test-project', tags: ['gamma'], query: 'Gamma' });
+      expect(good.length).toBe(1);
+      expect(good[0].id).toBe(node.id);
+    });
+  });
+
   describe('listProjects', () => {
     it('should list all projects with nodes in the graph', async () => {
       // Create nodes for different projects

--- a/src/engine/KnowledgeGraph.ts
+++ b/src/engine/KnowledgeGraph.ts
@@ -226,6 +226,33 @@ export class KnowledgeGraphManager {
     }
   }
 
+  async search({
+    project,
+    tags,
+    query,
+    limit,
+  }: {
+    project: string;
+    tags?: string[];
+    query?: string;
+    limit?: number;
+  }): Promise<DagNode[]> {
+    const q = query?.toLowerCase();
+    return this.export({
+      project,
+      limit,
+      filterFn: (node) => {
+        if (tags && (!node.tags || !tags.every((t) => node.tags!.includes(t)))) {
+          return false;
+        }
+        if (q && !node.thought.toLowerCase().includes(q)) {
+          return false;
+        }
+        return true;
+      },
+    });
+  }
+
   async listProjects(): Promise<string[]> {
     const projects = new Set<string>();
     const fileStream = fsSync.createReadStream(this.logFilePath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,6 +218,34 @@ async function main() {
     },
   );
 
+  server.tool(
+    'search_nodes',
+    'Search nodes by tags and/or text query',
+    {
+      projectContext: z.string().describe('Full path to the project directory.'),
+      tags: z.array(z.string()).optional().describe('Tags to match.'),
+      query: z.string().optional().describe('Substring to search for in thoughts.'),
+      limit: z.number().optional().describe('Limit the number of nodes returned.'),
+    },
+    async (a) => {
+      const projectName = await loadProjectOrThrow({ logger, args: a, onProjectLoad: runOnce });
+      const nodes = await kg.search({
+        project: projectName,
+        tags: a.tags,
+        query: a.query,
+        limit: a.limit,
+      });
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(nodes, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
   /** list_projects – list all available knowledge graph projects */
   server.tool(
     'list_projects',


### PR DESCRIPTION
## Summary
- implement `KnowledgeGraphManager.search` to filter nodes by tags and text
- expose `search_nodes` tool via MCP server
- document new tool in README
- cover `search` in KnowledgeGraph tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`