### PR TITLE
Add knowledge graph neighbor lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ CodeLoops provides tools to enable autonomous agent operation:
 - `search_nodes`: Filter nodes by tags or a text query.
 - `summarize`: Generates a summary of branch progress.
 - `list_projects`: Displays all projects for navigation.
+- `get_neighbors`: Retrieve a node along with its parents and children up to a specified depth.
 
 ## Basic Workflow
 

--- a/src/engine/KnowledgeGraph.test.ts
+++ b/src/engine/KnowledgeGraph.test.ts
@@ -263,6 +263,47 @@ describe('KnowledgeGraphManager', () => {
     });
   });
 
+  describe('getNeighbors', () => {
+    it('returns immediate neighbors by default', async () => {
+      const nodeA = createTestNode('test-project');
+      const nodeB = createTestNode('test-project');
+      const nodeC = createTestNode('test-project');
+
+      nodeA.children.push(nodeB.id);
+      nodeB.parents = [nodeA.id];
+      nodeA.parents.push(nodeC.id);
+
+      await kg.appendEntity(nodeB);
+      await kg.appendEntity(nodeA);
+      await kg.appendEntity(nodeC);
+
+      const neighbors = await kg.getNeighbors(nodeA.id);
+      const ids = neighbors.map((n) => n.id).sort();
+      expect(ids).toEqual([nodeA.id, nodeB.id, nodeC.id].sort());
+    });
+
+    it('respects the depth parameter', async () => {
+      const nodeA = createTestNode('test-project');
+      const nodeB = createTestNode('test-project');
+      const nodeC = createTestNode('test-project');
+
+      nodeA.children.push(nodeB.id);
+      nodeB.parents = [nodeA.id];
+      nodeB.children.push(nodeC.id);
+      nodeC.parents = [nodeB.id];
+
+      await kg.appendEntity(nodeC);
+      await kg.appendEntity(nodeB);
+      await kg.appendEntity(nodeA);
+
+      const depth1 = await kg.getNeighbors(nodeA.id, 1);
+      expect(depth1.map((n) => n.id).sort()).toEqual([nodeA.id, nodeB.id].sort());
+
+      const depth2 = await kg.getNeighbors(nodeA.id, 2);
+      expect(depth2.map((n) => n.id).sort()).toEqual([nodeA.id, nodeB.id, nodeC.id].sort());
+    });
+  });
+
   describe('listProjects', () => {
     it('should list all projects with nodes in the graph', async () => {
       // Create nodes for different projects

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,6 +175,35 @@ async function main() {
   );
 
   server.tool(
+    'get_neighbors',
+    'Get a node along with its parents and children up to the requested depth',
+    {
+      id: z.string().describe('ID of the node to retrieve neighbors for.'),
+      projectContext: z.string().describe('Full path to the project directory.'),
+      depth: z
+        .number()
+        .optional()
+        .describe('How many levels of neighbors to include. Defaults to 1.'),
+    },
+    async (a) => {
+      await loadProjectOrThrow({
+        logger,
+        args: { projectContext: a.projectContext },
+        onProjectLoad: runOnce,
+      });
+      const nodes = await kg.getNeighbors(a.id, a.depth);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(nodes, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
     'resume',
     'Pick up where you left off by fetching the most recent nodes from the knowledge graph for this project. Use limit to control the number of nodes returned. Increase it if you need more context.',
     {


### PR DESCRIPTION
## Summary
- expose `getNeighbors` on knowledge graph to fetch parents/children recursively
- register `get_neighbors` tool in the MCP server
- document the new tool in the README
- test neighbor retrieval

## Testing
- `npm run format`
- `npm run lint`
- `npm test`