### PR TITLE
Add artifact history retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ CodeLoops provides tools to enable autonomous agent operation:
 - `resume`: Retrieves recent branch context for continuity.
 - `export`: Exports the current graph for agent review.
 - `search_nodes`: Filter nodes by tags or a text query.
+- `artifact_history`: Retrieve all nodes referencing a specific artifact path.
 - `summarize`: Generates a summary of branch progress.
 - `list_projects`: Displays all projects for navigation.
 - `get_neighbors`: Retrieve a node along with its parents and children up to a specified depth.

--- a/src/engine/KnowledgeGraph.test.ts
+++ b/src/engine/KnowledgeGraph.test.ts
@@ -304,6 +304,42 @@ describe('KnowledgeGraphManager', () => {
     });
   });
 
+  describe('getArtifactHistory', () => {
+    it('returns nodes referencing a path', async () => {
+      const nodeA = createTestNode('test-project');
+      nodeA.artifacts = [{ name: 'A', path: 'src/a.ts' }];
+      await kg.appendEntity(nodeA);
+
+      const nodeB = createTestNode('test-project');
+      nodeB.artifacts = [{ name: 'A', path: 'src/a.ts' }];
+      await kg.appendEntity(nodeB);
+
+      const nodeC = createTestNode('test-project');
+      nodeC.artifacts = [{ name: 'B', path: 'src/b.ts' }];
+      await kg.appendEntity(nodeC);
+
+      const results = await kg.getArtifactHistory('test-project', 'src/a.ts');
+      expect(results.map((n) => n.id).sort()).toEqual([nodeA.id, nodeB.id].sort());
+    });
+
+    it('respects the limit parameter', async () => {
+      const node1 = createTestNode('test-project');
+      node1.artifacts = [{ name: 'A', path: 'file.ts' }];
+      const node2 = createTestNode('test-project');
+      node2.artifacts = [{ name: 'A', path: 'file.ts' }];
+      const node3 = createTestNode('test-project');
+      node3.artifacts = [{ name: 'A', path: 'file.ts' }];
+
+      await kg.appendEntity(node1);
+      await kg.appendEntity(node2);
+      await kg.appendEntity(node3);
+
+      const results = await kg.getArtifactHistory('test-project', 'file.ts', 2);
+      expect(results.length).toBe(2);
+      expect(results.map((n) => n.id)).toEqual([node2.id, node3.id]);
+    });
+  });
+
   describe('listProjects', () => {
     it('should list all projects with nodes in the graph', async () => {
       // Create nodes for different projects

--- a/src/engine/KnowledgeGraph.ts
+++ b/src/engine/KnowledgeGraph.ts
@@ -277,6 +277,14 @@ export class KnowledgeGraphManager {
     });
   }
 
+  async getArtifactHistory(project: string, path: string, limit?: number): Promise<DagNode[]> {
+    return this.export({
+      project,
+      limit,
+      filterFn: (node) => !!node.artifacts?.some((a) => a.path === path),
+    });
+  }
+
   async listProjects(): Promise<string[]> {
     const projects = new Set<string>();
     const fileStream = fsSync.createReadStream(this.logFilePath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -275,6 +275,23 @@ async function main() {
     },
   );
 
+  server.tool(
+    'artifact_history',
+    'Retrieve history for a specific artifact path',
+    {
+      projectContext: z.string().describe('Full path to the project directory.'),
+      path: z.string().describe('Artifact path to look up.'),
+      limit: z.number().optional().describe('Limit the number of nodes returned.'),
+    },
+    async (a) => {
+      const projectName = await loadProjectOrThrow({ logger, args: a, onProjectLoad: runOnce });
+      const nodes = await kg.getArtifactHistory(projectName, a.path, a.limit);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(nodes, null, 2) }],
+      };
+    },
+  );
+
   /** list_projects – list all available knowledge graph projects */
   server.tool(
     'list_projects',


### PR DESCRIPTION
## Summary
- implement `getArtifactHistory` in `KnowledgeGraph`
- expose `artifact_history` tool via MCP server
- document new tool in README
- test history retrieval for artifacts

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
