### PR TITLE
Add open task listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ CodeLoops provides tools to enable autonomous agent operation:
 - `summarize`: Generates a summary of branch progress.
 - `list_projects`: Displays all projects for navigation.
 - `get_neighbors`: Retrieve a node along with its parents and children up to a specified depth.
+- `list_open_tasks`: List actor nodes tagged `task` that aren't marked `task-complete`.
 
 ## Basic Workflow
 

--- a/src/engine/KnowledgeGraph.test.ts
+++ b/src/engine/KnowledgeGraph.test.ts
@@ -359,4 +359,23 @@ describe('KnowledgeGraphManager', () => {
       expect(projects).toEqual([]);
     });
   });
+
+  describe('listOpenTasks', () => {
+    it('returns only tasks without the task-complete tag', async () => {
+      const openTask = createTestNode('test-project');
+      openTask.tags = ['task'];
+      await kg.appendEntity(openTask);
+
+      const doneTask = createTestNode('test-project');
+      doneTask.tags = ['task', 'task-complete'];
+      await kg.appendEntity(doneTask);
+
+      const other = createTestNode('test-project');
+      other.tags = ['other'];
+      await kg.appendEntity(other);
+
+      const results = await kg.listOpenTasks('test-project');
+      expect(results.map((n) => n.id)).toEqual([openTask.id]);
+    });
+  });
 });

--- a/src/engine/KnowledgeGraph.ts
+++ b/src/engine/KnowledgeGraph.ts
@@ -285,6 +285,16 @@ export class KnowledgeGraphManager {
     });
   }
 
+  async listOpenTasks(project: string): Promise<DagNode[]> {
+    return this.export({
+      project,
+      filterFn: (node) =>
+        node.role === 'actor' &&
+        node.tags?.includes('task') &&
+        !node.tags?.includes('task-complete'),
+    });
+  }
+
   async listProjects(): Promise<string[]> {
     const projects = new Set<string>();
     const fileStream = fsSync.createReadStream(this.logFilePath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -292,6 +292,21 @@ async function main() {
     },
   );
 
+  server.tool(
+    'list_open_tasks',
+    'List actor nodes tagged "task" that have not been marked as "task-complete"',
+    {
+      projectContext: z.string().describe('Full path to the project directory.'),
+    },
+    async (a) => {
+      const projectName = await loadProjectOrThrow({ logger, args: a, onProjectLoad: runOnce });
+      const nodes = await kg.listOpenTasks(projectName);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(nodes, null, 2) }],
+      };
+    },
+  );
+
   /** list_projects – list all available knowledge graph projects */
   server.tool(
     'list_projects',


### PR DESCRIPTION
## Summary
- support listing open tasks in KnowledgeGraphManager
- expose `list_open_tasks` tool
- document the new tool
- test listing unfinished tasks only

## Testing
- `npm test`
- `npm run lint`
