### PR TITLE
Add tag enum and update tagging

### DIFF
--- a/src/agents/Summarize.ts
+++ b/src/agents/Summarize.ts
@@ -5,6 +5,7 @@ import { getInstance as getLogger } from '../logger.ts';
 import { fileURLToPath } from 'node:url';
 import { v4 as uuid } from 'uuid';
 import { DagNode, KnowledgeGraphManager, SummaryNode } from '../engine/KnowledgeGraph.ts';
+import { Tag } from '../engine/tags.ts';
 
 /**
  * SummarizationAgent provides an interface to the Python-based summarization agent.
@@ -49,14 +50,10 @@ export class SummarizationAgent {
 
       // Call the Python agent using execa
       const [execError, output] = await to(
-        execa(
-          this.pythonCommand,
-          [...this.pythonArgs, 'agent.py', '--quiet', '--summarize'],
-          {
-            cwd: this.agentPath,
-            input: nodesJson,
-          },
-        ),
+        execa(this.pythonCommand, [...this.pythonArgs, 'agent.py', '--quiet', '--summarize'], {
+          cwd: this.agentPath,
+          input: nodesJson,
+        }),
       );
 
       // Handle execution errors
@@ -194,7 +191,7 @@ export class SummarizationAgent {
       createdAt: '', // Will be set by appendEntity
       projectContext,
       summarizedSegment: nodes.map((node) => node.id),
-      tags: ['summary'],
+      tags: [Tag.Summary],
       artifacts: [],
     };
 

--- a/src/engine/ActorCriticEngine.ts
+++ b/src/engine/ActorCriticEngine.ts
@@ -3,6 +3,7 @@ import { Actor } from '../agents/Actor.ts';
 import { KnowledgeGraphManager, type DagNode, FILE_REF } from './KnowledgeGraph.ts';
 import { SummarizationAgent } from '../agents/Summarize.ts';
 import { z } from 'zod';
+import { TagEnum } from './tags.ts';
 // -----------------------------------------------------------------------------
 // Actor–Critic engine ----------------------------------------------------------
 // -----------------------------------------------------------------------------
@@ -29,7 +30,7 @@ export const ActorThinkSchema = {
     ),
 
   tags: z
-    .array(z.string())
+    .array(TagEnum)
     .min(1, 'Add at least one semantic tag – requirement, task, risk, design …')
     .describe('Semantic categories used for later search and deduping.'),
 

--- a/src/engine/KnowledgeGraph.ts
+++ b/src/engine/KnowledgeGraph.ts
@@ -7,6 +7,7 @@ import readline from 'node:readline';
 import { dataDir } from '../config.ts';
 import { CodeLoopsLogger } from '../logger.ts';
 import { ActorThinkInput } from './ActorCriticEngine.ts';
+import { TagEnum, Tag } from './tags.ts';
 
 // -----------------------------------------------------------------------------
 // Interfaces & Schemas --------------------------------------------------------
@@ -71,7 +72,7 @@ export class KnowledgeGraphManager {
     verdictReferences: z.array(z.string()).optional(),
     target: z.string().optional(),
     summarizedSegment: z.array(z.string()).optional(),
-    tags: z.array(z.string()).optional(),
+    tags: z.array(TagEnum).optional(),
     artifacts: z.array(FILE_REF).optional(),
   });
 
@@ -257,7 +258,7 @@ export class KnowledgeGraphManager {
     limit,
   }: {
     project: string;
-    tags?: string[];
+    tags?: Tag[];
     query?: string;
     limit?: number;
   }): Promise<DagNode[]> {
@@ -290,8 +291,8 @@ export class KnowledgeGraphManager {
       project,
       filterFn: (node) =>
         node.role === 'actor' &&
-        node.tags?.includes('task') &&
-        !node.tags?.includes('task-complete'),
+        node.tags?.includes(Tag.Task) &&
+        !node.tags?.includes(Tag.TaskComplete),
     });
   }
 

--- a/src/engine/tags.ts
+++ b/src/engine/tags.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export enum Tag {
+  Requirement = 'requirement',
+  Task = 'task',
+  Design = 'design',
+  Risk = 'risk',
+  TaskComplete = 'task-complete',
+  Summary = 'summary',
+}
+
+export const TagEnum = z.nativeEnum(Tag);
+export const TAGS = Object.values(Tag) as [string, ...string[]];

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { KnowledgeGraphManager } from './engine/KnowledgeGraph.ts';
 import { Critic } from './agents/Critic.ts';
 import { Actor } from './agents/Actor.ts';
 import { SummarizationAgent } from './agents/Summarize.ts';
+import { TagEnum } from './engine/tags.ts';
 import pkg from '../package.json' with { type: 'json' };
 import { CodeLoopsLogger, getInstance as getLogger, setGlobalLogger } from './logger.ts';
 import { extractProjectName } from './utils/project.ts';
@@ -77,14 +78,14 @@ async function main() {
   1. **Call 'actor_think' for all actions**:
      - Planning, requirement capture, task breakdown, or coding steps.
      - Use the 'projectContext' property to specify the full path to the currently open directory.
-  2. **Always include at least one semantic tag** (e.g., 'requirement', 'task', 'file-modification', 'task-complete') to enable searchability and trigger appropriate reviews.
+  2. **Always include at least one semantic tag** (e.g., 'requirement', 'task', 'design', 'risk', 'task-complete') to enable searchability and trigger appropriate reviews.
   3. **Iterative Workflow**:
      - File modifications or task completions automatically trigger critic reviews.
      - Use the critic's feedback (in 'criticNode') to refine your next thought.
   4. **Tags and artifacts are critical for tracking decisions and avoiding duplicate work**.
   
   **Example Workflow**:
-  - Step 1: Call 'actor_think' with thought: "Create main.ts with initial setup", projectContext: "/path/to/project", artifacts: ['src/main.ts'], tags: ['file-modification'].
+  - Step 1: Call 'actor_think' with thought: "Create main.ts with initial setup", projectContext: "/path/to/project", artifacts: ['src/main.ts'], tags: ['task'].
       - Response: Includes feedback from the critic
   - Step 2:  Make any necessary changes and call 'actor_think' again with the updated thought.
   - Repeat until the all work is completed.
@@ -252,7 +253,7 @@ async function main() {
     'Search nodes by tags and/or text query',
     {
       projectContext: z.string().describe('Full path to the project directory.'),
-      tags: z.array(z.string()).optional().describe('Tags to match.'),
+      tags: z.array(TagEnum).optional().describe('Tags to match.'),
       query: z.string().optional().describe('Substring to search for in thoughts.'),
       limit: z.number().optional().describe('Limit the number of nodes returned.'),
     },


### PR DESCRIPTION
## Summary
- add `Tag` enum and `TagEnum` helper
- validate tags using enum in `ActorThinkSchema` and `KnowledgeGraph`
- refactor search and listOpenTasks to use enum values
- update tests and docs to reference enum-based tags

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
