### PR TITLE
Add diff field to graph nodes

### DIFF
--- a/agents/critic/agent.py
+++ b/agents/critic/agent.py
@@ -28,6 +28,7 @@ interface DagNode {
   children: string[];
   createdAt: string; // ISO timestamp
   projectContext: string;// full path to the currently open directory in the code editor
+  diff?: string; // optional git-style diff summarizing code changes
   tags?: string[]; // categories ("design", "task", etc.)
   artifacts?: ArtifactRef[]; // attached artifacts
 }
@@ -39,6 +40,7 @@ The actor must follow these schema requirements:
 2. `tags`: Must include at least one semantic tag (requirement, task, risk, design, definition)
 3. `artifacts`: Must be included when files are referenced in the thought
 4. `projectContext`: Must be included to infer the project name from the last item in the path.
+5. `diff`: Optional git-style diff of code changes when applicable
 
 ## Your Review Process
 When reviewing an actor node:

--- a/src/agents/Actor.ts
+++ b/src/agents/Actor.ts
@@ -8,7 +8,15 @@ export class Actor {
   async think(
     input: ActorThinkInput & { artifacts?: Partial<ArtifactRef>[]; project: string },
   ): Promise<{ node: DagNode }> {
-    const { thought, tags, artifacts, project, projectContext, parents: inputParents } = input;
+    const {
+      thought,
+      tags,
+      artifacts,
+      project,
+      projectContext,
+      parents: inputParents,
+      diff,
+    } = input;
 
     const parents =
       inputParents && inputParents.length > 0
@@ -24,6 +32,7 @@ export class Actor {
       children: [],
       createdAt: '', // Will be set by appendEntity
       tags,
+      ...(diff && { diff }),
       artifacts: artifacts as ArtifactRef[],
       projectContext,
     };

--- a/src/engine/ActorCriticEngine.ts
+++ b/src/engine/ActorCriticEngine.ts
@@ -34,6 +34,9 @@ export const ActorThinkSchema = {
     .min(1, 'Add at least one semantic tag – requirement, task, risk, design …')
     .describe('Semantic categories used for later search and deduping.'),
 
+  /** Optional git-style diff summarizing code changes. */
+  diff: z.string().optional(),
+
   /** Optional parent node IDs this thought builds upon. */
   parents: z.array(z.string()).optional(),
 

--- a/src/engine/KnowledgeGraph.test.ts
+++ b/src/engine/KnowledgeGraph.test.ts
@@ -55,6 +55,7 @@ describe('KnowledgeGraphManager', () => {
     createdAt: '',
     tags: [Tag.Task],
     artifacts: [],
+    diff: undefined,
   });
 
   describe('appendEntity', () => {
@@ -78,6 +79,15 @@ describe('KnowledgeGraphManager', () => {
 
       // Verify it's a valid ISO date string
       expect(() => new Date(testNode.createdAt)).not.toThrow();
+    });
+
+    it('should store the diff field when provided', async () => {
+      const testNode = createTestNode('test-project');
+      testNode.diff = 'diff --git a/file b/file';
+      await kg.appendEntity(testNode);
+
+      const stored = await kg.getNode(testNode.id);
+      expect(stored?.diff).toBe('diff --git a/file b/file');
     });
 
     it('should not allow cycles in the graph', async () => {
@@ -414,6 +424,7 @@ describe('KnowledgeGraphManager', () => {
         artifacts: [],
         project: 'test-project',
         projectContext: '/path/to/test-project',
+        diff: 'diff text',
       });
 
       const all = await kg.allDagNodes('test-project');
@@ -423,6 +434,7 @@ describe('KnowledgeGraphManager', () => {
       expect(node.parents.sort()).toEqual([head1.id, head2.id].sort());
       expect(latestHead1?.children).toContain(node.id);
       expect(latestHead2?.children).toContain(node.id);
+      expect(node.diff).toBe('diff text');
     });
   });
 });

--- a/src/engine/KnowledgeGraph.ts
+++ b/src/engine/KnowledgeGraph.ts
@@ -38,6 +38,8 @@ export interface DagNode extends ActorThinkInput, WithProjectContext {
   verdictReason?: string;
   verdictReferences?: string[];
   target?: string; // nodeId this criticises
+  /** Optional git-style diff summarizing code changes. */
+  diff?: string;
   parents: string[];
   children: string[];
   createdAt: string; // ISO timestamp
@@ -72,6 +74,7 @@ export class KnowledgeGraphManager {
     verdictReferences: z.array(z.string()).optional(),
     target: z.string().optional(),
     summarizedSegment: z.array(z.string()).optional(),
+    diff: z.string().optional(),
     tags: z.array(TagEnum).optional(),
     artifacts: z.array(FILE_REF).optional(),
   });


### PR DESCRIPTION
## Summary
- support optional `diff` field in ActorThinkSchema and DagNode
- save diff string in `Actor.think`
- document new property for critic agent
- test diff persistence

## Testing
- `npm run format`
- `npm run lint`
- `npm test`