### PR TITLE
Fix getNode to return latest entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - docs: clarify Tag enum values in critic and summarize agents
+- fix: return latest node version when IDs repeat
 
 ## [0.3.6] - 2025-05-22
 

--- a/src/engine/KnowledgeGraph.test.ts
+++ b/src/engine/KnowledgeGraph.test.ts
@@ -130,6 +130,18 @@ describe('KnowledgeGraphManager', () => {
       const result = await kg.getNode(nonExistentId);
       expect(result).toBeUndefined();
     });
+
+    it('returns the latest entry when a node is updated', async () => {
+      const node = createTestNode('test-project');
+      await kg.appendEntity(node);
+
+      node.thought = 'updated thought';
+      await kg.appendEntity(node);
+
+      const retrieved = await kg.getNode(node.id);
+      expect(retrieved?.thought).toBe('updated thought');
+      expect(retrieved?.createdAt).toBe(node.createdAt);
+    });
   });
 
   describe('resume', () => {

--- a/src/engine/KnowledgeGraph.ts
+++ b/src/engine/KnowledgeGraph.ts
@@ -161,14 +161,15 @@ export class KnowledgeGraphManager {
   async getNode(id: string): Promise<DagNode | undefined> {
     const fileStream = fsSync.createReadStream(this.logFilePath);
     const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+    let found: DagNode | undefined;
     try {
       for await (const line of rl) {
         const entry = this.parseDagNode(line);
         if (entry?.id === id) {
-          return entry;
+          found = entry; // keep scanning for the latest entry
         }
       }
-      return undefined;
+      return found;
     } finally {
       rl.close();
       fileStream.close();


### PR DESCRIPTION
## Summary
- ensure `getNode` returns the most recent node in the log
- test retrieving the latest version after multiple updates
- document change in `CHANGELOG`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
