### PR TITLE
Update docs for new node fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - docs: clarify Tag enum values in critic and summarize agents
+- docs: document parents, diff, and tag values in README and overview
 - fix: return latest node version when IDs repeat
 - test: add ActorCriticEngine unit tests
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ Use codeloops to plan and implement the following:
 ... (insert your product requirements here)
 ```
 
+When calling `actor_think`, include metadata so future steps can follow the graph:
+
+- **`parents`** – IDs of prior nodes this thought builds on.
+- **`diff`** – optional git-style diff summarizing any code changes.
+- **`tags`** – semantic labels used for search. Valid options are:
+  - `requirement`
+  - `task`
+  - `design`
+  - `risk`
+  - `task-complete`
+  - `summary`
+
 ## Available Tools
 
 CodeLoops provides tools to enable autonomous agent operation:

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -82,6 +82,16 @@ High‑level flow: caller → MCP → KG + Actor/Critic loop
 The actor-critic system follows this workflow:
 
 1. The agent calls `actor_think` to add a new thought node to the knowledge graph
+   - Include metadata so the graph can track progress:
+     - **`parents`** – IDs of previous nodes this thought depends on
+     - **`diff`** – optional git-style diff summarizing code changes
+     - **`tags`** – categorize the node for later search. Valid options:
+       - `requirement`
+       - `task`
+       - `design`
+       - `risk`
+       - `task-complete`
+       - `summary`
 2. The critic evaluates the node and provides a verdict:
    - `approved`: The node meets all requirements
    - `needs_revision`: The node needs specific improvements


### PR DESCRIPTION
## Summary
- document parents, diff and tag enum in README
- mention node metadata in actor-critic workflow overview
- note documentation update in CHANGELOG

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
