### PR TITLE
docs: reference Tag enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - docs: document parents, diff, and tag values in README and overview
 - fix: return latest node version when IDs repeat
 - test: add ActorCriticEngine unit tests
+- feat: introduce Tag enum for thought tags and update docs
 
 ## [0.3.6] - 2025-05-22
 

--- a/README.md
+++ b/README.md
@@ -103,13 +103,14 @@ When calling `actor_think`, include metadata so future steps can follow the grap
 
 - **`parents`** – IDs of prior nodes this thought builds on.
 - **`diff`** – optional git-style diff summarizing any code changes.
-- **`tags`** – semantic labels used for search. Valid options are:
-  - `requirement`
-  - `task`
-  - `design`
-  - `risk`
-  - `task-complete`
-  - `summary`
+- **`tags`** – semantic labels used for search. Tags are defined in the
+  [`Tag` enum](./src/engine/tags.ts):
+  - `Tag.Requirement`
+  - `Tag.Task`
+  - `Tag.Design`
+  - `Tag.Risk`
+  - `Tag.TaskComplete`
+  - `Tag.Summary`
 
 ## Available Tools
 

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -85,13 +85,14 @@ The actor-critic system follows this workflow:
    - Include metadata so the graph can track progress:
      - **`parents`** – IDs of previous nodes this thought depends on
      - **`diff`** – optional git-style diff summarizing code changes
-     - **`tags`** – categorize the node for later search. Valid options:
-       - `requirement`
-       - `task`
-       - `design`
-       - `risk`
-       - `task-complete`
-       - `summary`
+     - **`tags`** – categorize the node for later search. Tags are defined in the
+       [`Tag` enum`](../src/engine/tags.ts):
+       - `Tag.Requirement`
+       - `Tag.Task`
+       - `Tag.Design`
+       - `Tag.Risk`
+       - `Tag.TaskComplete`
+       - `Tag.Summary`
 2. The critic evaluates the node and provides a verdict:
    - `approved`: The node meets all requirements
    - `needs_revision`: The node needs specific improvements


### PR DESCRIPTION
## Summary
- document Tag enum usage in README and overview
- note Tag enum addition in CHANGELOG

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
