### PR TITLE
Add LOG_LEVEL support to logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat: configurable log level via LOG_LEVEL environment variable
 - fix: detect cycles when child already links back to its parent
 - fix: correct cycle detection in KnowledgeGraph to prevent false positives
 - docs: clarify Tag enum values in critic and summarize agents

--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ inputs remain. See
 [`genai-node-reference.md`](./genai-node-reference.md) for details on the
 Gemini caching API.
 
+### Log Level
+
+Control log verbosity by setting the `LOG_LEVEL` environment variable
+(e.g. `debug`, `info`, `warn`). Defaults to `info` if unset.
+
 ### Configure Your Agent
 
 Connect your agent to the CodeLoops server by adding the MCP server configuration. Most platforms follow a similar structure:

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -14,6 +14,7 @@ interface CreateLoggerOptions {
   withFile?: boolean;
   sync?: boolean;
   setGlobal?: boolean;
+  level?: string;
 }
 
 const logsDir = path.resolve(__dirname, '../logs');
@@ -53,7 +54,8 @@ export function createLogger(options?: CreateLoggerOptions): CodeLoopsLogger {
     targets,
     ...(options ?? {}),
   });
-  const logger = pino(transports);
+  const level = options?.level ?? process.env.LOG_LEVEL ?? 'info';
+  const logger = pino({ level }, transports);
   if (options?.setGlobal && !globalLogger) {
     globalLogger = logger;
   }


### PR DESCRIPTION
## Summary
- allow `createLogger` to set level from options or LOG_LEVEL env var
- document LOG_LEVEL usage
- note change in CHANGELOG

## Testing
- `npm run lint`
- `npm test`
- `npm run type-check`
