### PR TITLE
Reduce summarization logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat: add debug logger and lower verbosity for summarization agent logs
 - feat: configurable log level via LOG_LEVEL environment variable
 - fix: detect cycles when child already links back to its parent
 - fix: correct cycle detection in KnowledgeGraph to prevent false positives

--- a/src/agents/Summarize.ts
+++ b/src/agents/Summarize.ts
@@ -46,7 +46,7 @@ export class SummarizationAgent {
       const nodesJson = JSON.stringify(nodes);
 
       // Log input for debugging
-      getLogger().info({ nodesJson }, 'Summarization agent input');
+      getLogger().debug({ nodesJson }, 'Summarization agent input');
 
       // Call the Python agent using execa
       const [execError, output] = await to(
@@ -71,7 +71,7 @@ export class SummarizationAgent {
       }
 
       // Log raw output for debugging
-      getLogger().info({ rawOutput: output.stdout }, 'Summarization agent raw output');
+      getLogger().debug({ rawOutput: output.stdout }, 'Summarization agent raw output');
 
       // Parse the response with improved error handling
       let response;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -75,3 +75,7 @@ export function getInstance(options?: CreateLoggerOptions): CodeLoopsLogger {
 export function setGlobalLogger(logger: CodeLoopsLogger) {
   globalLogger = logger;
 }
+
+export function debug(...args: Parameters<CodeLoopsLogger['debug']>): void {
+  getInstance().debug(...args);
+}


### PR DESCRIPTION
## Notes
- add a `debug` helper in `logger.ts`
- lower verbosity of summarization agent logging
- document change in `CHANGELOG.md`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
