### PR TITLE
Update log level docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+- docs: warn that `LOG_LEVEL=debug` may fill disk space quickly
 - feat: truncate debug output for summarization agent logs
 
 - feat: configure Gemini thinking budget via `GENAI_THINKING_BUDGET` env var

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Control log verbosity by setting the `LOG_LEVEL` environment variable or
 passing a `level` option to `createLogger`/`getInstance` (e.g. `debug`,
 `info`, `warn`). Defaults to `info` if unset.
 
+> **Note**: Setting `LOG_LEVEL=debug` writes large log entries and can quickly
+> fill disk space. Use `info` unless you need deep debugging.
+
 ### Configure Your Agent
 
 Connect your agent to the CodeLoops server by adding the MCP server configuration. Most platforms follow a similar structure:


### PR DESCRIPTION
## Summary
- warn that `LOG_LEVEL=debug` can rapidly fill disk space
- mention this new recommendation in the changelog

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
