### PR TITLE
Disable summarizer progress logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- fix: disable summarization progress display to prevent runaway logs
+
 - feat: apply `GENAI_THINKING_BUDGET` when generating Gemini content
 - docs: warn that `LOG_LEVEL=debug` may fill disk space quickly
 - feat: truncate debug output for summarization agent logs

--- a/agents/summarize/fastagent.config.template.yaml
+++ b/agents/summarize/fastagent.config.template.yaml
@@ -21,8 +21,9 @@ logger:
   # type: "none" | "console" | "file" | "http"
   # path: "/path/to/logfile.jsonl"
 
+  level: info
   # Switch the progress display on or off
-  progress_display: true
+  progress_display: false
 
   # Show chat User/Assistant messages on the console
   show_chat: false


### PR DESCRIPTION
## Summary
- disable progress spinner in summarization agent config template
- note change in the changelog

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
