### PR TITLE
Add summarizer config update notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- docs: advise refreshing summarizer config to disable progress display
+- chore: warn if summarizer config still uses progress_display in setup script
 - fix: disable summarization progress display to prevent runaway logs
 
 - feat: apply `GENAI_THINKING_BUDGET` when generating Gemini content

--- a/README.md
+++ b/README.md
@@ -86,6 +86,20 @@ passing a `level` option to `createLogger`/`getInstance` (e.g. `debug`,
 > **Note**: Setting `LOG_LEVEL=debug` writes large log entries and can quickly
 > fill disk space. Use `info` unless you need deep debugging.
 
+### Refresh Summarizer Config
+
+Older installations may still have progress display enabled for the
+summarization agent. Make sure `agents/summarize/fastagent.config.yaml`
+contains:
+
+```yaml
+logger:
+  level: info
+  progress_display: false
+```
+
+Copy `fastagent.config.template.yaml` over the existing file if needed.
+
 ### Configure Your Agent
 
 Connect your agent to the CodeLoops server by adding the MCP server configuration. Most platforms follow a similar structure:

--- a/docs/INSTALL_GUIDE.md
+++ b/docs/INSTALL_GUIDE.md
@@ -132,6 +132,18 @@ For more info on LLM providers and models, see the [fast-agent docs](https://fas
    uv run fast-agent check
    ```
 
+> **Important**: Recent updates disable progress logs in the summarization
+> agent. If you installed CodeLoops before this change, edit
+> `agents/summarize/fastagent.config.yaml` and ensure it contains:
+>
+> ```yaml
+> logger:
+>   level: info
+>   progress_display: false
+> ```
+>
+> You can copy the latest template over the file if needed.
+
 For more info on LLM providers and models, see the [fast-agent docs](https://fast-agent.ai/models/llm_providers/)
 
 #### 4.3 Understanding `uv sync`

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -166,6 +166,10 @@ if [ $? -eq 0 ]; then
     cp fastagent.config.template.yaml fastagent.config.yaml
     echo -e "✅ ${GREEN}Created fastagent.config.yaml${NC}"
   fi
+  if grep -q "progress_display: true" fastagent.config.yaml; then
+    echo -e "⚠️  ${YELLOW}progress_display is enabled in Summarize fastagent.config.yaml.${NC}"
+    echo -e "${YELLOW}Set progress_display: false to reduce log noise.${NC}"
+  fi
   if [ ! -f fastagent.secrets.yaml ]; then
     cp fastagent.secrets.template.yaml fastagent.secrets.yaml
     echo -e "✅ ${GREEN}Created fastagent.secrets.yaml${NC}"


### PR DESCRIPTION
## Summary
- warn that summarizer config should disable progress display
- show how to refresh the config in README and INSTALL_GUIDE
- warn in setup script if progress logs are still enabled

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
