### PR TITLE
Disable progress logs by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- chore: progress logs disabled by default in agent configs
+
 - docs: advise refreshing summarizer config to disable progress display
 - chore: warn if summarizer config still uses progress_display in setup script
 - fix: disable summarization progress display to prevent runaway logs

--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ passing a `level` option to `createLogger`/`getInstance` (e.g. `debug`,
 > **Note**: Setting `LOG_LEVEL=debug` writes large log entries and can quickly
 > fill disk space. Use `info` unless you need deep debugging.
 
-### Refresh Summarizer Config
+### Progress Logging
 
-Older installations may still have progress display enabled for the
-summarization agent. Make sure `agents/summarize/fastagent.config.yaml`
-contains:
+Progress logs are disabled by default for both agents. If you installed
+CodeLoops before this change, check that `fastagent.config.yaml` for each
+agent contains:
 
 ```yaml
 logger:
@@ -98,7 +98,9 @@ logger:
   progress_display: false
 ```
 
-Copy `fastagent.config.template.yaml` over the existing file if needed.
+Set the value to `true` if you prefer to see a progress bar in the
+console. You can copy `fastagent.config.template.yaml` over an existing
+file if needed.
 
 ### Configure Your Agent
 

--- a/agents/critic/fastagent.config.template.yaml
+++ b/agents/critic/fastagent.config.template.yaml
@@ -22,7 +22,7 @@ logger:
   # path: "/path/to/logfile.jsonl"
 
   # Switch the progress display on or off
-  progress_display: true
+  progress_display: false
 
   # Show chat User/Assistant messages on the console
   show_chat: false

--- a/docs/INSTALL_GUIDE.md
+++ b/docs/INSTALL_GUIDE.md
@@ -132,9 +132,9 @@ For more info on LLM providers and models, see the [fast-agent docs](https://fas
    uv run fast-agent check
    ```
 
-> **Important**: Recent updates disable progress logs in the summarization
-> agent. If you installed CodeLoops before this change, edit
-> `agents/summarize/fastagent.config.yaml` and ensure it contains:
+> **Important**: Progress logs are disabled by default. If you installed
+> CodeLoops before this change, edit each `fastagent.config.yaml` and
+> ensure it contains:
 >
 > ```yaml
 > logger:
@@ -142,7 +142,8 @@ For more info on LLM providers and models, see the [fast-agent docs](https://fas
 >   progress_display: false
 > ```
 >
-> You can copy the latest template over the file if needed.
+> Set the value to `true` if you want a progress bar. You can copy the
+> latest template over the file if needed.
 
 For more info on LLM providers and models, see the [fast-agent docs](https://fast-agent.ai/models/llm_providers/)
 


### PR DESCRIPTION
## Summary
- disable `progress_display` in critic template
- update docs to describe the new default
- note change in changelog

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
