### PR TITLE
Cap summarization stderr logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - chore: progress logs disabled by default in agent configs
 
+- fix: cap summarization agent stderr logs to avoid runaway output
+
 - docs: advise refreshing summarizer config to disable progress display
 - chore: warn if summarizer config still uses progress_display in setup script
 - fix: disable summarization progress display to prevent runaway logs

--- a/src/agents/Summarize.ts
+++ b/src/agents/Summarize.ts
@@ -72,9 +72,13 @@ export class SummarizationAgent {
         };
       }
 
-      // Handle stderr output
-      if (output.stderr) {
-        getLogger().error({ stderr: output.stderr }, 'Summarization agent stderr output');
+      // Handle stderr output with truncated preview to prevent log flooding
+      const errPreview =
+        output.stderr && output.stderr.length > MAX_DEBUG_LENGTH
+          ? `${output.stderr.slice(0, MAX_DEBUG_LENGTH)}...`
+          : output.stderr;
+      if (errPreview) {
+        getLogger().error({ stderr: errPreview }, 'Summarization agent stderr output');
       }
 
       // Log raw output for debugging with truncated preview


### PR DESCRIPTION
## Summary
- cap stderr logs from the summarization agent for readability
- document change in changelog

## Testing
- `npm run lint`
- `npm test`
