### PR TITLE
Update setup progress check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- chore: warn if critic config still uses progress_display in setup script
 - chore: progress logs disabled by default in agent configs
 
 - fix: cap summarization agent stderr logs to avoid runaway output

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -170,6 +170,10 @@ if [ $? -eq 0 ]; then
     echo -e "⚠️  ${YELLOW}progress_display is enabled in Summarize fastagent.config.yaml.${NC}"
     echo -e "${YELLOW}Set progress_display: false to reduce log noise.${NC}"
   fi
+  if [ -f ../critic/fastagent.config.yaml ] && grep -q "progress_display: true" ../critic/fastagent.config.yaml; then
+    echo -e "⚠️  ${YELLOW}progress_display is enabled in Critic fastagent.config.yaml.${NC}"
+    echo -e "${YELLOW}Set progress_display: false to reduce log noise.${NC}"
+  fi
   if [ ! -f fastagent.secrets.yaml ]; then
     cp fastagent.secrets.template.yaml fastagent.secrets.yaml
     echo -e "✅ ${GREEN}Created fastagent.secrets.yaml${NC}"


### PR DESCRIPTION
## Summary
- warn if progress_display is true in critic config
- mention behavior in changelog

## Testing
- `npm test`
- `npm run lint`
