### PR TITLE
Optimize node retrieval with recent nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- perf: faster resume and list methods with getRecentNodes
 
 - fix: cycle detection only traverses children links when validating new parents
 - feat: cache DagNodes in KnowledgeGraphManager with configurable expiration


### PR DESCRIPTION
## Summary
- add `getRecentNodes` for faster access to last log entries
- use `getRecentNodes` in `resume`, `listOpenTasks`, and `getHeads`
- add optional limit param for `listOpenTasks` and `getHeads`
- extend unit tests for optimized paths
- document performance boost in changelog

## Testing
- `npm run lint`
- `npm test`