### PR TITLE
Optimize file handle usage in getRecentNodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+
 - perf: faster resume and list methods with getRecentNodes
+- perf: reuse file handle when reading recent nodes
 
 - fix: cycle detection only traverses children links when validating new parents
 - feat: cache DagNodes in KnowledgeGraphManager with configurable expiration


### PR DESCRIPTION
## Summary
- reuse a single file handle while reading recent nodes
- update changelog

## Testing
- `npm run lint`
- `npm test`
